### PR TITLE
[maimai] rewrite rating algorithm

### DIFF
--- a/library/src/algorithms/maimai-rate.test.ts
+++ b/library/src/algorithms/maimai-rate.test.ts
@@ -44,8 +44,8 @@ t.test("maimai Rate Tests", (t) => {
 		MakeTestCase(13, 100.61, 11.7, 0.35),
 		MakeTestCase(9, 100.26, 10.5, 0),
 
-		MakeTestCase(100, 100, 13.9, 17.8),
-		MakeTestCase(96.99, 100, 8.9, 0),
+		MakeTestCase(100, 100, 13.9, 18.8),
+		MakeTestCase(96.99, 100, 8.9, 7.95),
 	];
 
 	for (const testCase of testCases) {
@@ -66,16 +66,8 @@ t.test("maimai Rate Validation Tests", (t) => {
 		() => calculate(101.5, 100.68, 10),
 		"Should throw if score is greater than max score."
 	);
-	ThrowsToSnapshot(
-		t,
-		() => calculate(-1, 100.68, 10),
-		"Should throw if score is negative."
-	);
-	ThrowsToSnapshot(
-		t,
-		() => calculate(99.5, 100.68, -1),
-		"Should throw if level is negative."
-	);
+	ThrowsToSnapshot(t, () => calculate(-1, 100.68, 10), "Should throw if score is negative.");
+	ThrowsToSnapshot(t, () => calculate(99.5, 100.68, -1), "Should throw if level is negative.");
 
 	t.end();
 });

--- a/library/src/algorithms/maimai-rate.test.ts
+++ b/library/src/algorithms/maimai-rate.test.ts
@@ -46,6 +46,9 @@ t.test("maimai Rate Tests", (t) => {
 
 		MakeTestCase(100, 100, 13.9, 18.8),
 		MakeTestCase(96.99, 100, 8.9, 7.95),
+
+		// Levels beyond 15 should be extrapolated from lv14 and 15 values
+		MakeTestCase(100.9, 100.9, 15.4, 21.8),
 	];
 
 	for (const testCase of testCases) {

--- a/library/src/algorithms/maimai-rate.ts
+++ b/library/src/algorithms/maimai-rate.ts
@@ -39,13 +39,14 @@ const RANK_BOUNDARIES: Record<string, number> = {
 	"SSS+": 104,
 };
 
+// @ts-expect-error getRank is called after the score is checked for validity
+// (between 0 and 104), so not having an ending return statement is OK.
 function getRank(score: number): keyof typeof RANK_BOUNDARIES {
 	for (const [rank, boundary] of Object.entries(RANK_BOUNDARIES).reverse()) {
 		if (score >= boundary) {
 			return rank;
 		}
 	}
-	return "F";
 }
 
 function calculateCurve(internalChartLevel: number): number[] {


### PR DESCRIPTION
Turns out there were no algorithms to begin with; play rating is determined by a table stored in the game, and scaled linearly for in-between values.

Another correction is that `score == maxScore == 100` is considered an AP+/SSS+ by the game, and so play rating is maximum.