### PR TITLE
[chunithm] fix rating for SSS/SSS+

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -21,7 +21,7 @@
 	},
 	"dependencies": {},
 	"name": "rg-stats",
-	"version": "0.5.0",
+	"version": "0.5.2",
 	"description": "A library for calculating various rhythm game stats.",
 	"main": "js/main.js",
 	"scripts": {

--- a/library/src/algorithms/chunithm-rating.test.ts
+++ b/library/src/algorithms/chunithm-rating.test.ts
@@ -14,6 +14,7 @@ t.test("CHUNITHM Rating Tests", (t) => {
 	t.equal(calculate(925_000, LEVEL), LEVEL - 3);
 	t.equal(calculate(900_000, LEVEL), LEVEL - 5);
 	t.equal(calculate(800_000, LEVEL), 3.75);
+	t.equal(calculate(500_000, LEVEL), 0);
 	t.equal(calculate(0, LEVEL), 0);
 
 	// Also, lets just test some random values inbetween. This should
@@ -26,6 +27,7 @@ t.test("CHUNITHM Rating Tests", (t) => {
 	t.equal(calculate(950_000, LEVEL), 11);
 	t.equal(calculate(920_000, LEVEL), 9.1);
 	t.equal(calculate(810_000, LEVEL), 4.12);
+	t.equal(calculate(600_000, LEVEL), 1.25);
 	t.equal(calculate(50_000, LEVEL), 0);
 
 	t.end();

--- a/library/src/algorithms/chunithm-rating.test.ts
+++ b/library/src/algorithms/chunithm-rating.test.ts
@@ -6,7 +6,8 @@ t.test("CHUNITHM Rating Tests", (t) => {
 	// Test all the cutoffs for a random chart level
 	// are where they should be.
 	const LEVEL = 12.5;
-	t.equal(calculate(1_010_000, LEVEL), LEVEL + 2);
+	t.equal(calculate(1_010_000, LEVEL), LEVEL + 2.15);
+	t.equal(calculate(1_007_500, LEVEL), LEVEL + 2);
 	t.equal(calculate(1_005_000, LEVEL), LEVEL + 1.5);
 	t.equal(calculate(1_000_000, LEVEL), LEVEL + 1);
 	t.equal(calculate(975_000, LEVEL), LEVEL);
@@ -18,7 +19,7 @@ t.test("CHUNITHM Rating Tests", (t) => {
 	// Also, lets just test some random values inbetween. This should
 	// give us decent coverage of the formula.
 	t.equal(calculate(987_000, LEVEL), 12.98);
-	t.equal(calculate(1_008_000, LEVEL), 14.5);
+	t.equal(calculate(1_008_000, LEVEL), 14.55);
 	t.equal(calculate(1_003_000, LEVEL), 13.8);
 	t.equal(calculate(999_000, LEVEL), 13.46);
 	t.equal(calculate(980_000, LEVEL), 12.7);
@@ -33,8 +34,8 @@ t.test("CHUNITHM Rating Tests", (t) => {
 t.test("CHUNITHM Rating Edge Cases", (t) => {
 	t.equal(
 		calculate(1_010_000, 0),
-		2,
-		"A perfect score on a chart with level 0 should be valid, and worth 0 + 2."
+		2.15,
+		"A perfect score on a chart with level 0 should be valid, and worth 0 + 2.15."
 	);
 	t.equal(calculate(0, 12.5), 0, "A score of 0 should be worth 0.");
 	t.equal(calculate(0, 0), 0, "A score of 0 on a chart with level 0 should be worth 0.");

--- a/library/src/algorithms/chunithm-rating.ts
+++ b/library/src/algorithms/chunithm-rating.ts
@@ -32,6 +32,8 @@ export function calculate(score: number, internalChartLevel: number) {
 		val = levelBase - 500 + ((score - 900_000) * 4) / 500;
 	} else if (score >= 800_000) {
 		val = (levelBase - 500) / 2 + ((score - 800_000) * ((levelBase - 500) / 2)) / 100_000;
+	} else if (score >= 500_000) {
+		val = (((levelBase - 500) / 2) * (score - 500_000)) / 300_000;
 	}
 
 	return Math.max(Math.floor(val) / 100, 0);

--- a/library/src/algorithms/chunithm-rating.ts
+++ b/library/src/algorithms/chunithm-rating.ts
@@ -16,8 +16,10 @@ export function calculate(score: number, internalChartLevel: number) {
 
 	let val = 0;
 
-	if (score >= 1_007_500) {
-		val = levelBase + 200;
+	if (score >= 1_009_000) {
+		val = levelBase + 215;
+	} else if (score >= 1_007_500) {
+		val = levelBase + 200 + (score - 1_007_500) / 100;
 	} else if (score >= 1_005_000) {
 		val = levelBase + 150 + ((score - 1_005_000) * 10) / 500;
 	} else if (score >= 1_000_000) {

--- a/library/tap-snapshots/src/algorithms/maimaidx-rate.test.ts.test.cjs
+++ b/library/tap-snapshots/src/algorithms/maimaidx-rate.test.ts.test.cjs
@@ -5,14 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Inverse Rate Validation Tests > Should throw if level is negative. 1`] = `
-Invalid input, Internal chart level cannot be negative. level=-1.
-`
-
-exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Inverse Rate Validation Tests > Should throw if rate is impossible. 1`] = `
-Invalid input, A rate of 100 is not possible on a chart of level 1. rate=100, level=1.
-`
-
 exports[`src/algorithms/maimaidx-rate.test.ts TAP maimai DX Rate Validation Tests > Should throw if level is negative. 1`] = `
 Invalid input, Internal chart level cannot be negative. level=-1.
 `


### PR DESCRIPTION
the rating cap was changed to +2.15 (at SSS+) in CHUNITHM NEW, and rating for SSS ranks now scale with their score.

additionally, rating is also calculated for scores between 500k and 800k